### PR TITLE
Make grench main return a proper exit code

### DIFF
--- a/client.ml
+++ b/client.ml
@@ -5,77 +5,52 @@ open Printf
 let exit = Pervasives.exit
 
 let ns = ref "user"
+let exit_code = ref 0
 
 let eval_message code ns session =
-  ([("session", session);
-    ("op", "eval");
-    ("id", "eval-" ^ (Uuid.to_string (Uuid.create ())));
-    ("ns", ns);
-    ("code", code ^ "\n")],
-   Nrepl.default_actions)
-
-let stdin_message input session =
-  let uuid = Uuid.to_string (Uuid.create ()) in
-  ([("op", "stdin");
-    ("id", uuid);
-    ("stdin", input ^ "\n");
-    ("session", session)],
-   Nrepl.default_actions)
-
-let stacktrace_message =
-  eval_message "(clojure.stacktrace/print-cause-trace *e)" "user"
-
-let print_stacktrace w p resp  =
-  match List.Assoc.find resp "session" with
-    | Some Bencode.String(session) ->
-      Nrepl.send w p (stacktrace_message session)
-    | Some _ | None -> eprintf "  eval-error with no session."
+  Nrepl.eval_message
+    code ns
+    ~actions:{ Nrepl.default_actions with
+               Nrepl.value = fun v ->
+                             try
+                               exit_code := int_of_string v
+                             with
+                               Failure "int_of_string" -> ()}
+    session
 
 let send_input resp (r,w,p) result =
-  match List.Assoc.find resp "session" with
-    | Some Bencode.String(session) -> (match result with
-        | Some input -> Nrepl.send w p (stdin_message input session)
+  match (Nrepl.response_session resp) with
+    | Some session -> (match result with
+        | Some input -> Nrepl.send w p (Nrepl.stdin_message input session)
         (* TODO: only exit on EOF in a top-level input request *)
         | None -> Nrepl.debug "Eof seen"; exit 0)
-    | None | Some _ -> eprintf "  No session in need-input."
+    | None -> eprintf "  No session in need-input."
 
-let remove_pending pending id =
-  Nrepl.debug ("-p " ^ String.concat ~sep:" " (Hashtbl.keys pending));
-  match id with
-    | Some Bencode.String(id) -> if Hashtbl.mem pending id then
-        Hashtbl.remove pending id
-    | None | Some _ -> eprintf "  Unknown message id.\n%!"
-
-let handle_done (r,w,p) _ =
-  if Hashtbl.keys p = ["init"] then exit 0
+let handle_done (r,w,p) resp =
+  if Nrepl.pending_ids p = ["init"] then
+    exit !exit_code
 
 let rec handler handle_done (r,w,p) raw resp =
-  let handle actions k v = match (k, v) with
-    | ("out", out) -> actions.Nrepl.out out
-    | ("err", out) -> actions.Nrepl.err out
-    | ("ex", out) | ("root-ex", out) -> actions.Nrepl.ex out
-    | ("value", value) -> actions.Nrepl.value value
+
+  let resp_actions = Nrepl.response_actions p resp in
+
+  let handle k v = match (k, v) with
+    | ("out", out) -> resp_actions.Nrepl.out out
+    | ("err", out) -> resp_actions.Nrepl.err out
+    | ("ex", out) | ("root-ex", out) -> resp_actions.Nrepl.ex out
+    | ("value", value) -> resp_actions.Nrepl.value value
     | ("ns", new_ns) -> ns := new_ns
     | ("session", _) | ("id", _) -> ()
     | (k, v) -> printf "  Unknown response: %s %s\n%!" k v in
 
-  let resp_actions resp =
-    let lookup_actions id = match Hashtbl.find p id with
-      | Some actions -> actions
-      | None -> Nrepl.default_actions in
-    match List.Assoc.find resp "id" with
-    | Some Bencode.String id -> lookup_actions id
-    | Some _ -> eprintf "  Unknown id type\n%!";
-                Nrepl.default_actions
-    | None -> Nrepl.default_actions in
-
-  let handle_status resp status =
+  let handle_status status =
     match status with
       | Bencode.String "done" ->
-        remove_pending p (List.Assoc.find resp "id");
+        Nrepl.remove_pending p (Nrepl.response_id resp);
+        resp_actions.Nrepl.after_message ();
         handle_done (r,w,p) resp
       | Bencode.String "eval-error" ->
-        print_stacktrace w p resp
+         resp_actions.Nrepl.eval_error (r,w,p) resp
       | Bencode.String "unknown-session" ->
         eprintf "Unknown session.\n"
       | Bencode.String "need-input" ->
@@ -83,14 +58,15 @@ let rec handler handle_done (r,w,p) raw resp =
       | Bencode.String "interrupted" -> print_newline ()
       | x -> printf "  Unknown status: %s\n%!" (Bencode.marshal x) in
 
-  let handle_clause resp clause =
+  let handle_clause clause =
     match clause with
-      | k, Bencode.String v -> handle (resp_actions resp) k v
-      | "status", Bencode.List(status) -> List.iter status (handle_status resp)
+      | k, Bencode.String v -> handle k v
+      | "status", Bencode.List(status) -> List.iter status handle_status
       | k, v ->
-        eprintf "  Unknown %s response: %s %s\n%!" (Bencode.string_of_type v) k raw in
+        eprintf "  Unknown %s response: %s %s\n%!"
+                (Bencode.string_of_type v) k raw in
 
-  List.iter resp (handle_clause resp)
+  List.iter resp handle_clause
 
 let eval port messages handle_done =
   let handler = handler handle_done in
@@ -122,7 +98,8 @@ let main_form =
                (catch Exception e
                  (let [c (:exit-code (ex-data e))]
                    (when-not (and (number? c) (zero? c))
-                     (print-cause-trace e)))))))"
+                     (print-cause-trace e))
+                   c)))))"
 
 let main port args =
   match args with


### PR DESCRIPTION
Tracks the value returned by eval, and uses it for the exit code.

Also refactors access to the response and pending hash-table into nrepl.ml.
