### PR TITLE
Add ctypes-foreign install

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To build, run the following commands:
 
     $ git clone git@github.com:technomancy/grenchman.git grenchman
     $ cd grenchman
-    $ opam install ocamlfind core async ctypes
+    $ opam install ocamlfind core async ctypes ctypes-foreign
     $ ocamlbuild -use-ocamlfind -lflags -cclib,-lreadline grench.native
     $ ln -s $PWD/grench.native ~/bin/grench # or somewhere on your $PATH
 


### PR DESCRIPTION
I needed to install ctypes-foreign as well to get it to build.

```sh
$ocamlbuild -use-ocamlfind -lflags -cclib,-lreadline grench.native
File "_tags", line 1, characters 71-80:
Warning: the tag "debugging" is not used in any flag declaration, so it will have no effect; it may be a typo. Otherwise use `mark_tag_used` in your myocamlbuild.ml to disable this warning.
+ ocamlfind ocamldep -package core -package async -package ctypes.foreign -modules grench.ml > grench.ml.depends
ocamlfind: Package `ctypes.foreign.unthreaded' not found - required by `ctypes.foreign'
Command exited with code 2.
Compilation unsuccessful after building 1 target (0 cached) in 00:00:00.
```